### PR TITLE
Upgrade smpita/configas to v2 and smpita/typeas to v4

### DIFF
--- a/.cursor/rules/laravel-boost.mdc
+++ b/.cursor/rules/laravel-boost.mdc
@@ -479,4 +479,124 @@ $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 | overflow-ellipsis | text-ellipsis |
 | decoration-slice | box-decoration-slice |
 | decoration-clone | box-decoration-clone |
+
+
+=== smpita/configas rules ===
+
+### Typed Config Resolver for Laravel
+
+- Use \Smpita\ConfigAs\ConfigAs to resolve like config() but with type hints.
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. ConfigAs::array('key', default: []) and ConfigAs::class(Expected::class, 'key', default: new Expected()).
+- Helpers like configArray(), configNullableArray(), configBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\ConfigAs\configArray;
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = ConfigAs::array('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = ConfigAs::nullableArray('key');
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = ConfigAs::bool('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = ConfigAs::nullableBool('key');
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = ConfigAs::class(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = ConfigAs::nullableClass(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = ConfigAs::float('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = ConfigAs::nullableFloat('key');
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = ConfigAs::int('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = ConfigAs::nullableInt('key');
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = ConfigAs::string('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = ConfigAs::nullableString('key');
+</code-snippet>
+
+
+=== smpita/typeas rules ===
+
+### Guaranteed type control for PHP
+
+- Use \Smpita\TypeAs\TypeAs to narrow types when handling mixed type signatures.
+- Avoid casts like (string) and (int). Use TypeAs::string() and TypeAs::int() and similar methods instead.
+- Use nullable methods like TypeAs::nullableArray() and TypeAs::nullableFloat() when a null is a feasible value.
+- TypeAs::array() will wrap non-iterable values in an array. Use the wrap parameter to control this behavior, e.g. TypeAs::array($mixed, wrap: false).
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. TypeAs::array($mixed, default: []) and TypeAs::class(Expected::class, $mixed, default: new Expected()).
+- Helpers like asArray(), asNullableArray(), asBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\TypeAs\asArray;
+- A custom resolver that implements the appropriate Smpita\TypeAs\Contracts interface can be provided as the third parameter, e.g. TypeAs::array($mixed, resolver: new ArrayResolver()).
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = TypeAs::array($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = TypeAs::nullableArray($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = TypeAs::bool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = TypeAs::nullableBool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = TypeAs::class(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = TypeAs::nullableClass(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = TypeAs::float($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = TypeAs::nullableFloat($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = TypeAs::int($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = TypeAs::nullableInt($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = TypeAs::string($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = TypeAs::nullableString($mixed);
+</code-snippet>
 </laravel-boost-guidelines>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,4 +476,124 @@ $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 | overflow-ellipsis | text-ellipsis |
 | decoration-slice | box-decoration-slice |
 | decoration-clone | box-decoration-clone |
+
+
+=== smpita/configas rules ===
+
+### Typed Config Resolver for Laravel
+
+- Use \Smpita\ConfigAs\ConfigAs to resolve like config() but with type hints.
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. ConfigAs::array('key', default: []) and ConfigAs::class(Expected::class, 'key', default: new Expected()).
+- Helpers like configArray(), configNullableArray(), configBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\ConfigAs\configArray;
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = ConfigAs::array('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = ConfigAs::nullableArray('key');
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = ConfigAs::bool('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = ConfigAs::nullableBool('key');
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = ConfigAs::class(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = ConfigAs::nullableClass(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = ConfigAs::float('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = ConfigAs::nullableFloat('key');
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = ConfigAs::int('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = ConfigAs::nullableInt('key');
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = ConfigAs::string('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = ConfigAs::nullableString('key');
+</code-snippet>
+
+
+=== smpita/typeas rules ===
+
+### Guaranteed type control for PHP
+
+- Use \Smpita\TypeAs\TypeAs to narrow types when handling mixed type signatures.
+- Avoid casts like (string) and (int). Use TypeAs::string() and TypeAs::int() and similar methods instead.
+- Use nullable methods like TypeAs::nullableArray() and TypeAs::nullableFloat() when a null is a feasible value.
+- TypeAs::array() will wrap non-iterable values in an array. Use the wrap parameter to control this behavior, e.g. TypeAs::array($mixed, wrap: false).
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. TypeAs::array($mixed, default: []) and TypeAs::class(Expected::class, $mixed, default: new Expected()).
+- Helpers like asArray(), asNullableArray(), asBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\TypeAs\asArray;
+- A custom resolver that implements the appropriate Smpita\TypeAs\Contracts interface can be provided as the third parameter, e.g. TypeAs::array($mixed, resolver: new ArrayResolver()).
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = TypeAs::array($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = TypeAs::nullableArray($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = TypeAs::bool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = TypeAs::nullableBool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = TypeAs::class(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = TypeAs::nullableClass(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = TypeAs::float($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = TypeAs::nullableFloat($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = TypeAs::int($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = TypeAs::nullableInt($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = TypeAs::string($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = TypeAs::nullableString($mixed);
+</code-snippet>
 </laravel-boost-guidelines>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,4 +476,124 @@ $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 | overflow-ellipsis | text-ellipsis |
 | decoration-slice | box-decoration-slice |
 | decoration-clone | box-decoration-clone |
+
+
+=== smpita/configas rules ===
+
+### Typed Config Resolver for Laravel
+
+- Use \Smpita\ConfigAs\ConfigAs to resolve like config() but with type hints.
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. ConfigAs::array('key', default: []) and ConfigAs::class(Expected::class, 'key', default: new Expected()).
+- Helpers like configArray(), configNullableArray(), configBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\ConfigAs\configArray;
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = ConfigAs::array('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = ConfigAs::nullableArray('key');
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = ConfigAs::bool('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = ConfigAs::nullableBool('key');
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = ConfigAs::class(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = ConfigAs::nullableClass(Expected::class, 'key');
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = ConfigAs::float('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = ConfigAs::nullableFloat('key');
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = ConfigAs::int('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = ConfigAs::nullableInt('key');
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = ConfigAs::string('key');
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = ConfigAs::nullableString('key');
+</code-snippet>
+
+
+=== smpita/typeas rules ===
+
+### Guaranteed type control for PHP
+
+- Use \Smpita\TypeAs\TypeAs to narrow types when handling mixed type signatures.
+- Avoid casts like (string) and (int). Use TypeAs::string() and TypeAs::int() and similar methods instead.
+- Use nullable methods like TypeAs::nullableArray() and TypeAs::nullableFloat() when a null is a feasible value.
+- TypeAs::array() will wrap non-iterable values in an array. Use the wrap parameter to control this behavior, e.g. TypeAs::array($mixed, wrap: false).
+- Default values can be provided as the second parameter, or the third parameter for class, e.g. TypeAs::array($mixed, default: []) and TypeAs::class(Expected::class, $mixed, default: new Expected()).
+- Helpers like asArray(), asNullableArray(), asBool(), etc are available for all types but they need to be imported, e.g. use function Smpita\TypeAs\asArray;
+- A custom resolver that implements the appropriate Smpita\TypeAs\Contracts interface can be provided as the third parameter, e.g. TypeAs::array($mixed, resolver: new ArrayResolver()).
+
+
+<code-snippet name="How to type as array" lang="php">
+$array = TypeAs::array($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable array" lang="php">
+$nullableArray = TypeAs::nullableArray($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as bool" lang="php">
+$bool = TypeAs::bool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable bool" lang="php">
+$nullableBool = TypeAs::nullableBool($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as class" lang="php">
+$class = TypeAs::class(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable class" lang="php">
+$nullableClass = TypeAs::nullableClass(Expected::class, $mixed);
+</code-snippet>
+
+<code-snippet name="How to type as float" lang="php">
+$float = TypeAs::float($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable float" lang="php">
+$nullableFloat = TypeAs::nullableFloat($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as int" lang="php">
+$int = TypeAs::int($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable int" lang="php">
+$nullableInt = TypeAs::nullableInt($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as string" lang="php">
+$string = TypeAs::string($mixed);
+</code-snippet>
+
+<code-snippet name="How to type as nullable string" lang="php">
+$nullableString = TypeAs::nullableString($mixed);
+</code-snippet>
 </laravel-boost-guidelines>

--- a/boost.json
+++ b/boost.json
@@ -11,5 +11,8 @@
         "cursor",
         "opencode"
     ],
-    "guidelines": []
+    "guidelines": [
+        "smpita/configas",
+        "smpita/typeas"
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "lendable/composer-license-checker": "^1.2",
         "livewire/flux": "^2.4",
         "livewire/flux-pro": "^2.4",
-        "smpita/configas": "^1.2",
-        "smpita/typeas": "^3.1",
+        "smpita/configas": "^2.0",
+        "smpita/typeas": "^4.0",
         "spatie/laravel-activitylog": "^4.10",
         "wire-elements/pro": "^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd6c1a7dcd6f9a286e4077ddec6c94ab",
+    "content-hash": "b074eb587d10184a301bcb264b57ffe2",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -686,24 +686,24 @@
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3"
+                "phpoption/phpoption": "^1.9.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
             "type": "library",
             "autoload": {
@@ -732,7 +732,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -744,7 +744,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:45:45+00:00"
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2462,16 +2462,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -2489,7 +2489,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -2549,7 +2549,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -2561,7 +2561,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3038,16 +3038,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -3097,7 +3097,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -3109,7 +3109,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T11:53:16+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -3854,22 +3854,22 @@
         },
         {
             "name": "smpita/configas",
-            "version": "v1.4.1",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smpita/configas.git",
-                "reference": "c797f9760b28e0b226c87f92bccda2f36550f898"
+                "reference": "c091b4c22b33805d05f2990e0cea8ec7de3635fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smpita/configas/zipball/c797f9760b28e0b226c87f92bccda2f36550f898",
-                "reference": "c797f9760b28e0b226c87f92bccda2f36550f898",
+                "url": "https://api.github.com/repos/smpita/configas/zipball/c091b4c22b33805d05f2990e0cea8ec7de3635fd",
+                "reference": "c091b4c22b33805d05f2990e0cea8ec7de3635fd",
                 "shasum": ""
             },
             "require": {
                 "illuminate/contracts": ">=10.0",
                 "php": ">=8.1",
-                "smpita/typeas": "^3.2.2"
+                "smpita/typeas": "^4.0.1"
             },
             "require-dev": {
                 "laravel/pint": ">=1.0",
@@ -3903,7 +3903,7 @@
             ],
             "support": {
                 "issues": "https://github.com/smpita/configas/issues",
-                "source": "https://github.com/smpita/configas/tree/v1.4.1"
+                "source": "https://github.com/smpita/configas/tree/v2.0.1"
             },
             "funding": [
                 {
@@ -3911,20 +3911,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-29T14:54:27+00:00"
+            "time": "2025-12-27T21:14:29+00:00"
         },
         {
             "name": "smpita/typeas",
-            "version": "v3.2.2",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smpita/typeas.git",
-                "reference": "08aff83e77a95cd40b28a781b45c0427f20f8a7b"
+                "reference": "5a84fbe2a5ebe5cc94f24804ba0f165a4948de90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smpita/typeas/zipball/08aff83e77a95cd40b28a781b45c0427f20f8a7b",
-                "reference": "08aff83e77a95cd40b28a781b45c0427f20f8a7b",
+                "url": "https://api.github.com/repos/smpita/typeas/zipball/5a84fbe2a5ebe5cc94f24804ba0f165a4948de90",
+                "reference": "5a84fbe2a5ebe5cc94f24804ba0f165a4948de90",
                 "shasum": ""
             },
             "require": {
@@ -3956,7 +3956,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Easy type control for static analysis",
+            "description": "Guaranteed type control for PHP",
             "homepage": "https://github.com/smpita/typeas",
             "keywords": [
                 "laravel",
@@ -3965,9 +3965,9 @@
             ],
             "support": {
                 "issues": "https://github.com/smpita/typeas/issues",
-                "source": "https://github.com/smpita/typeas/tree/v3.2.2"
+                "source": "https://github.com/smpita/typeas/tree/v4.0.2"
             },
-            "time": "2025-11-23T17:55:24+00:00"
+            "time": "2025-12-27T20:04:47+00:00"
         },
         {
             "name": "spatie/laravel-activitylog",
@@ -4200,16 +4200,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.1",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e"
+                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
+                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
                 "shasum": ""
             },
             "require": {
@@ -4274,7 +4274,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.1"
+                "source": "https://github.com/symfony/console/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -4294,7 +4294,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T15:23:39+00:00"
+            "time": "2025-12-23T14:50:43+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -4677,16 +4677,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
+                "reference": "fffe05569336549b20a1be64250b40516d6e8d06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fffe05569336549b20a1be64250b40516d6e8d06",
+                "reference": "fffe05569336549b20a1be64250b40516d6e8d06",
                 "shasum": ""
             },
             "require": {
@@ -4721,7 +4721,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.0"
+                "source": "https://github.com/symfony/finder/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -4741,20 +4741,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T05:42:40+00:00"
+            "time": "2025-12-23T14:50:43+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.1",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27"
+                "reference": "a70c745d4cea48dbd609f4075e5f5cbce453bd52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bd1af1e425811d6f077db240c3a588bdb405cd27",
-                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a70c745d4cea48dbd609f4075e5f5cbce453bd52",
+                "reference": "a70c745d4cea48dbd609f4075e5f5cbce453bd52",
                 "shasum": ""
             },
             "require": {
@@ -4803,7 +4803,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.1"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -4823,20 +4823,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-07T11:13:10+00:00"
+            "time": "2025-12-23T14:23:49+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.2",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f"
+                "reference": "885211d4bed3f857b8c964011923528a55702aa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6e6f0a5fa8763f75a504b930163785fb6dd055f",
-                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/885211d4bed3f857b8c964011923528a55702aa5",
+                "reference": "885211d4bed3f857b8c964011923528a55702aa5",
                 "shasum": ""
             },
             "require": {
@@ -4922,7 +4922,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.2"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -4942,20 +4942,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T07:43:37+00:00"
+            "time": "2025-12-31T08:43:57+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd"
+                "reference": "e472d35e230108231ccb7f51eb6b2100cac02ee4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
-                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/e472d35e230108231ccb7f51eb6b2100cac02ee4",
+                "reference": "e472d35e230108231ccb7f51eb6b2100cac02ee4",
                 "shasum": ""
             },
             "require": {
@@ -5006,7 +5006,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.0"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -5026,7 +5026,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T15:26:00+00:00"
+            "time": "2025-12-16T08:02:06+00:00"
         },
         {
             "name": "symfony/mime",
@@ -5948,16 +5948,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8"
+                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
+                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
                 "shasum": ""
             },
             "require": {
@@ -5989,7 +5989,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.0"
+                "source": "https://github.com/symfony/process/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -6009,20 +6009,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T11:21:06+00:00"
+            "time": "2025-12-19T10:00:43+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "4720254cb2644a0b876233d258a32bf017330db7"
+                "reference": "5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/4720254cb2644a0b876233d258a32bf017330db7",
-                "reference": "4720254cb2644a0b876233d258a32bf017330db7",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090",
+                "reference": "5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090",
                 "shasum": ""
             },
             "require": {
@@ -6074,7 +6074,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.0"
+                "source": "https://github.com/symfony/routing/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -6094,7 +6094,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2025-12-19T10:00:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6275,16 +6275,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.1",
+            "version": "v8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "770e3b8b0ba8360958abedcabacd4203467333ca"
+                "reference": "60a8f11f0e15c48f2cc47c4da53873bb5b62135d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/770e3b8b0ba8360958abedcabacd4203467333ca",
-                "reference": "770e3b8b0ba8360958abedcabacd4203467333ca",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/60a8f11f0e15c48f2cc47c4da53873bb5b62135d",
+                "reference": "60a8f11f0e15c48f2cc47c4da53873bb5b62135d",
                 "shasum": ""
             },
             "require": {
@@ -6344,7 +6344,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.1"
+                "source": "https://github.com/symfony/translation/tree/v8.0.3"
             },
             "funding": [
                 {
@@ -6364,7 +6364,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2025-12-21T10:59:45+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -6528,16 +6528,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.0",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece"
+                "reference": "7e99bebcb3f90d8721890f2963463280848cba92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/41fd6c4ae28c38b294b42af6db61446594a0dece",
-                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7e99bebcb3f90d8721890f2963463280848cba92",
+                "reference": "7e99bebcb3f90d8721890f2963463280848cba92",
                 "shasum": ""
             },
             "require": {
@@ -6591,7 +6591,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.3"
             },
             "funding": [
                 {
@@ -6611,7 +6611,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-27T20:36:44+00:00"
+            "time": "2025-12-18T07:04:31+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6670,26 +6670,26 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.2",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.3",
+                "graham-campbell/result-type": "^1.1.4",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3",
-                "symfony/polyfill-ctype": "^1.24",
-                "symfony/polyfill-mbstring": "^1.24",
-                "symfony/polyfill-php80": "^1.24"
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -6738,7 +6738,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
             },
             "funding": [
                 {
@@ -6750,7 +6750,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-30T23:37:27+00:00"
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -9529,16 +9529,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.2.0",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "7c43c1c5834435ed9f4ad635e9cb1f0064f876bd"
+                "reference": "e86bec3e68f1874c112ca782fb9db1333f3fe7ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/7c43c1c5834435ed9f4ad635e9cb1f0064f876bd",
-                "reference": "7c43c1c5834435ed9f4ad635e9cb1f0064f876bd",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/e86bec3e68f1874c112ca782fb9db1333f3fe7ab",
+                "reference": "e86bec3e68f1874c112ca782fb9db1333f3fe7ab",
                 "shasum": ""
             },
             "require": {
@@ -9550,12 +9550,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.3",
+                "phpunit/phpunit": "^12.5.4",
                 "symfony/process": "^7.4.0|^8.0.0"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.3",
+                "phpunit/phpunit": ">12.5.4",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -9563,7 +9563,7 @@
                 "pestphp/pest-dev-tools": "^4.0.0",
                 "pestphp/pest-plugin-browser": "^4.1.1",
                 "pestphp/pest-plugin-type-coverage": "^4.0.3",
-                "psy/psysh": "^0.12.17"
+                "psy/psysh": "^0.12.18"
             },
             "bin": [
                 "bin/pest"
@@ -9629,7 +9629,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.2.0"
+                "source": "https://github.com/pestphp/pest/tree/v4.3.0"
             },
             "funding": [
                 {
@@ -9641,7 +9641,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-15T11:49:28+00:00"
+            "time": "2025-12-30T19:48:33+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -10849,16 +10849,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.3",
+            "version": "12.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6dc2e076d09960efbb0c1272aa9bc156fc80955e"
+                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6dc2e076d09960efbb0c1272aa9bc156fc80955e",
-                "reference": "6dc2e076d09960efbb0c1272aa9bc156fc80955e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
+                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
                 "shasum": ""
             },
             "require": {
@@ -10926,7 +10926,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.4"
             },
             "funding": [
                 {
@@ -10950,7 +10950,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-11T08:52:59+00:00"
+            "time": "2025-12-15T06:05:34+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -43,7 +42,6 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
             "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "core-js-pure": "^3.43.0"
             },
@@ -55,7 +53,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@defstudio/vite-livewire-plugin/-/vite-livewire-plugin-3.0.2.tgz",
             "integrity": "sha512-e+6zpZzK70eMzkD0sCAzKpOXDpD9g8nnQ08OAaL2W/uWtgjL9ibi7k08UbR7tEmrUN/bdYe32DWpg8MjMM7rVA==",
-            "license": "MIT",
             "dependencies": {
                 "minimatch": "^10.0.1",
                 "vite-plugin-full-reload": "^1.1.0"
@@ -74,7 +71,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "aix"
@@ -90,7 +86,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -106,7 +101,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -122,7 +116,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -138,7 +131,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -154,7 +146,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -170,7 +161,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -186,7 +176,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -202,7 +191,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -218,7 +206,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -234,7 +221,6 @@
             "cpu": [
                 "ia32"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -250,7 +236,6 @@
             "cpu": [
                 "loong64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -266,7 +251,6 @@
             "cpu": [
                 "mips64el"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -282,7 +266,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -298,7 +281,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -314,7 +296,6 @@
             "cpu": [
                 "s390x"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -330,7 +311,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -346,7 +326,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -362,7 +341,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -378,7 +356,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -394,7 +371,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -410,7 +386,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
@@ -426,7 +401,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
@@ -442,7 +416,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -458,7 +431,6 @@
             "cpu": [
                 "ia32"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -474,7 +446,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -487,7 +458,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
             "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "license": "MIT",
             "engines": {
                 "node": "20 || >=22"
             }
@@ -496,7 +466,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
             "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "license": "MIT",
             "dependencies": {
                 "@isaacs/balanced-match": "^4.0.1"
             },
@@ -509,7 +478,6 @@
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -526,7 +494,6 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -536,7 +503,6 @@
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -546,7 +512,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -554,14 +519,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "license": "MIT"
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -572,7 +535,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -586,7 +548,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -596,7 +557,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -609,15 +569,13 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
             "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=14"
@@ -628,7 +586,6 @@
             "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.24.0.tgz",
             "integrity": "sha512-x9l65fCE/pgoET6RQowgdgG8Xmzs44z6j6Hhg3coINCyCw9JBGJ5ZzMR2XHAM2jmAdbJAIgqB6cUn4/3W3XLTA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "linguist-languages": "^8.0.0",
                 "php-parser": "^3.2.5"
@@ -644,7 +601,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -657,7 +613,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -670,7 +625,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -683,7 +637,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -696,7 +649,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -709,7 +661,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -722,7 +673,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -735,7 +685,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -748,7 +697,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -761,7 +709,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -774,7 +721,6 @@
             "cpu": [
                 "loong64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -787,7 +733,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -800,7 +745,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -813,7 +757,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -826,7 +769,6 @@
             "cpu": [
                 "s390x"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -839,7 +781,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -852,7 +793,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -865,7 +805,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
@@ -878,7 +817,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -891,7 +829,6 @@
             "cpu": [
                 "ia32"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -904,7 +841,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -917,7 +853,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -928,7 +863,6 @@
             "resolved": "https://registry.npmjs.org/@shufo/tailwindcss-class-sorter/-/tailwindcss-class-sorter-3.0.1.tgz",
             "integrity": "sha512-y9SMobvwElX2G6vdg4odJ6UL6hu/o5RlMsdwEeDLGaqHU3BLSw9CeitGgBus6kadjjDdT2wseG0Tl5yXWdc4UQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.1.1",
                 "object-hash": "^3.0.0",
@@ -943,7 +877,6 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -953,7 +886,6 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
             "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -990,7 +922,6 @@
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
             "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
                 "enhanced-resolve": "^5.18.3",
@@ -1005,7 +936,6 @@
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
             "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             },
@@ -1031,7 +961,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -1047,7 +976,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1063,7 +991,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1079,7 +1006,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -1095,7 +1021,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1111,7 +1036,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1127,7 +1051,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1143,7 +1066,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1159,7 +1081,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1183,7 +1104,6 @@
             "cpu": [
                 "wasm32"
             ],
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@emnapi/core": "^1.7.1",
@@ -1204,7 +1124,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1220,7 +1139,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1233,7 +1151,6 @@
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
             "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
-            "license": "MIT",
             "dependencies": {
                 "@tailwindcss/node": "4.1.18",
                 "@tailwindcss/oxide": "4.1.18",
@@ -1246,15 +1163,13 @@
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "license": "MIT"
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
         },
         "node_modules/abbrev": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
             "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -1264,7 +1179,6 @@
             "resolved": "https://registry.npmjs.org/aigle/-/aigle-1.14.1.tgz",
             "integrity": "sha512-bCmQ65CEebspmpbWFs6ab3S27TNyVH1b5MledX8KoiGxUhsJmPUUGpaoSijhwawNnq5Lt8jbcq7Z7gUAD0nuTw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "aigle-core": "^1.0.0"
             }
@@ -1273,15 +1187,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/aigle-core/-/aigle-core-1.0.0.tgz",
             "integrity": "sha512-uGFWPumk5DLvYnUphNnff+kWC8VeAnjPbbU8ovsSHflKXGX77SD7cAN/aSBCLX3xnoJAM9KdtRgxUygRnSSu7A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/ajv": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1298,7 +1210,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -1310,7 +1221,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -1325,15 +1235,13 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -1347,7 +1255,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -1359,14 +1266,12 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT"
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/autoprefixer": {
             "version": "10.4.23",
@@ -1386,7 +1291,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.1",
                 "caniuse-lite": "^1.0.30001760",
@@ -1408,7 +1312,6 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
             "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-            "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
@@ -1419,14 +1322,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/baseline-browser-mapping": {
             "version": "2.9.11",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
             "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
-            "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
             }
@@ -1436,7 +1337,6 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -1449,7 +1349,6 @@
             "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.44.2.tgz",
             "integrity": "sha512-ulULHtiDVfaaFq80tGFtueK7c85lrkAyV1WK+Z8ubKJzOaaQlPOhYOaQFkC7JTsZZIjkkYFXWKGA4SZAmKT5mg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@prettier/plugin-php": "^0.24.0",
                 "@shufo/tailwindcss-class-sorter": "3.0.1",
@@ -1485,7 +1384,6 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -1495,7 +1393,6 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
             "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -1533,7 +1430,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -1543,7 +1439,6 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -1569,7 +1464,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -1588,14 +1482,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -1609,15 +1501,14 @@
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001761",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
-            "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
+            "version": "1.0.30001762",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+            "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1631,14 +1522,12 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1655,7 +1544,6 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -1680,7 +1568,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -1692,7 +1579,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -1706,7 +1592,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1714,14 +1599,12 @@
         "node_modules/cliui/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/cliui/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -1735,7 +1618,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -1747,7 +1629,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -1764,7 +1645,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -1775,14 +1655,12 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1795,7 +1673,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
             "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
@@ -1808,7 +1685,6 @@
             "engines": [
                 "node >= 6.0"
             ],
-            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -1820,7 +1696,6 @@
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
             "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-            "license": "MIT",
             "dependencies": {
                 "chalk": "4.1.2",
                 "rxjs": "7.8.2",
@@ -1844,7 +1719,6 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -1860,7 +1734,6 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
             "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -1872,7 +1745,6 @@
             "integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -1883,7 +1755,6 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1898,7 +1769,6 @@
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
             },
@@ -1910,7 +1780,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1920,7 +1789,6 @@
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
             "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1929,7 +1797,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
             }
@@ -1938,21 +1805,18 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-            "dev": true,
-            "license": "Apache-2.0"
+            "dev": true
         },
         "node_modules/dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -1966,15 +1830,13 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/editorconfig": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
             "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@one-ini/wasm": "0.1.1",
                 "commander": "^10.0.0",
@@ -1993,7 +1855,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
             "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2007,21 +1868,18 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-            "license": "ISC"
+            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/enhanced-resolve": {
             "version": "5.18.4",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
             "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -2034,7 +1892,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2043,7 +1900,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2052,7 +1908,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -2064,7 +1919,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -2080,7 +1934,6 @@
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
             "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -2120,7 +1973,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2129,15 +1981,13 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -2154,7 +2004,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -2176,15 +2025,13 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ],
-            "license": "BSD-3-Clause"
+            ]
         },
         "node_modules/fastq": {
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -2193,7 +2040,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -2211,7 +2057,6 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -2224,7 +2069,6 @@
             "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
             "integrity": "sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "user-home": "^2.0.0"
             },
@@ -2242,7 +2086,6 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -2257,7 +2100,6 @@
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
@@ -2273,7 +2115,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
             "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -2289,7 +2130,6 @@
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
             "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-            "license": "MIT",
             "engines": {
                 "node": "*"
             },
@@ -2303,7 +2143,6 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2316,7 +2155,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -2325,7 +2163,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -2334,7 +2171,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -2358,7 +2194,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -2372,7 +2207,6 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -2393,7 +2227,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -2406,7 +2239,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2421,7 +2253,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2432,14 +2263,12 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "license": "ISC"
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -2448,7 +2277,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2460,7 +2288,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -2475,7 +2302,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -2488,7 +2314,6 @@
             "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.3.tgz",
             "integrity": "sha512-HWSvaXJki44tg0uR1t+j5pRdUVpNiZcJaoB/PFhss/YoAw9cxUDLCpIBbLWQmKjBQfWk91P6LaRnredEyabrDw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -2498,7 +2323,6 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
             "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
@@ -2507,22 +2331,19 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -2535,7 +2356,6 @@
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
             "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -2551,7 +2371,6 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2560,7 +2379,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -2570,7 +2388,6 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -2583,7 +2400,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -2592,15 +2408,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -2615,7 +2429,6 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -2625,7 +2438,6 @@
             "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
             "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "config-chain": "^1.1.13",
                 "editorconfig": "^1.0.4",
@@ -2647,7 +2459,6 @@
             "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
             "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
@@ -2656,14 +2467,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/laravel-vite-plugin": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.0.1.tgz",
             "integrity": "sha512-zQuvzWfUKQu9oNVi1o0RZAJCwhGsdhx4NEOyrVQwJHaWDseGP9tl7XUPLY2T8Cj6+IrZ6lmyxlR1KC8unf3RLA==",
-            "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "vite-plugin-full-reload": "^1.1.0"
@@ -2682,7 +2491,6 @@
             "version": "1.30.2",
             "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
             "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-            "license": "MPL-2.0",
             "dependencies": {
                 "detect-libc": "^2.0.3"
             },
@@ -2714,7 +2522,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "android"
@@ -2734,7 +2541,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -2754,7 +2560,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -2774,7 +2579,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "freebsd"
@@ -2794,7 +2598,6 @@
             "cpu": [
                 "arm"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -2814,7 +2617,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -2834,7 +2636,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -2854,7 +2655,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -2874,7 +2674,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -2894,7 +2693,6 @@
             "cpu": [
                 "arm64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -2914,7 +2712,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -2932,7 +2729,6 @@
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
             "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14"
             },
@@ -2944,35 +2740,30 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/linguist-languages": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-8.2.0.tgz",
             "integrity": "sha512-KCUUH9x97QWYU0SXOCGxUrZR6cSfuQrMhABB7L/0I8N0LXOeaKe7+RZs7FAwvWCV2qKfZ4Wv1luLq4OfMezSJg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
@@ -2981,7 +2772,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2991,7 +2781,6 @@
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -3001,7 +2790,6 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -3015,7 +2803,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -3027,7 +2814,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3036,7 +2822,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -3048,7 +2833,6 @@
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
             "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/brace-expansion": "^5.0.0"
             },
@@ -3064,7 +2848,6 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -3074,7 +2857,6 @@
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
@@ -3091,7 +2873,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -3102,15 +2883,13 @@
         "node_modules/node-releases": {
             "version": "2.0.27",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT"
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="
         },
         "node_modules/nopt": {
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
             "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "abbrev": "^2.0.0"
             },
@@ -3126,7 +2905,6 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3136,7 +2914,6 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3146,7 +2923,6 @@
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
@@ -3156,7 +2932,6 @@
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3165,15 +2940,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
+            "dev": true
         },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3182,15 +2955,13 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/path-scurry": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -3206,20 +2977,17 @@
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.2.5.tgz",
             "integrity": "sha512-M1ZYlALFFnESbSdmRtTQrBFUHSriHgPhgqtTF/LCbZM4h7swR5PHtUceB2Kzby5CfqcsYwBn7OXTJ0+8Sajwkw==",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "dev": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "license": "ISC"
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -3232,7 +3000,6 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3242,7 +3009,6 @@
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
             "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
@@ -3251,7 +3017,6 @@
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
             "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "playwright-core": "1.57.0"
             },
@@ -3269,7 +3034,6 @@
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
             "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-            "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -3295,7 +3059,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3310,7 +3073,6 @@
             "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
             "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.0.0",
                 "read-cache": "^1.0.0",
@@ -3338,7 +3100,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "camelcase-css": "^2.0.1"
             },
@@ -3364,7 +3125,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "lilconfig": "^3.1.1"
             },
@@ -3407,7 +3167,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "postcss-selector-parser": "^6.1.1"
             },
@@ -3423,7 +3182,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -3435,15 +3193,13 @@
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "license": "MIT"
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
         "node_modules/prettier": {
             "version": "3.7.4",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
             "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -3458,14 +3214,12 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -3485,15 +3239,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "pify": "^2.3.0"
             }
@@ -3503,7 +3255,6 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3518,7 +3269,6 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -3531,7 +3281,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -3543,7 +3292,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3553,7 +3301,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3563,7 +3310,6 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
             "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
@@ -3584,7 +3330,6 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -3594,7 +3339,6 @@
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
             "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
-            "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -3638,7 +3382,6 @@
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -3663,7 +3406,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
@@ -3672,7 +3414,6 @@
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -3695,15 +3436,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/semver": {
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3716,7 +3455,6 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -3729,7 +3467,6 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3738,7 +3475,6 @@
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
             "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3751,7 +3487,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=14"
             },
@@ -3763,7 +3498,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3773,7 +3507,6 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -3783,7 +3516,6 @@
             "resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-2.0.0.tgz",
             "integrity": "sha512-AHMupZscUiDh07F1QziX7PLoB1DQ/pzu19vc8Xa8LwZcgnOXaw7yCgBuSYrxVEfaM2d8scc3Gtp+i+QJZV+spw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.12"
             }
@@ -3793,7 +3525,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -3812,7 +3543,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -3827,7 +3557,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3836,15 +3565,13 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -3857,7 +3584,6 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -3874,7 +3600,6 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -3887,7 +3612,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3897,7 +3621,6 @@
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
             "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "commander": "^4.0.0",
@@ -3920,7 +3643,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
@@ -3929,7 +3651,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3942,7 +3663,6 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3953,14 +3673,12 @@
         "node_modules/tailwindcss": {
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-            "license": "MIT"
+            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="
         },
         "node_modules/tapable": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
             "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -3974,7 +3692,6 @@
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0"
             }
@@ -3984,7 +3701,6 @@
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "thenify": ">= 3.1.0 < 4"
             },
@@ -3996,7 +3712,6 @@
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3"
@@ -4013,7 +3728,6 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -4025,7 +3739,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
             "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-            "license": "MIT",
             "bin": {
                 "tree-kill": "cli.js"
             }
@@ -4034,21 +3747,18 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-            "dev": true,
-            "license": "Apache-2.0"
+            "dev": true
         },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
@@ -4068,7 +3778,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -4085,7 +3794,6 @@
             "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
             "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "os-homedir": "^1.0.0"
             },
@@ -4097,14 +3805,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/vite": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
             "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -4178,7 +3884,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
             "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
-            "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
@@ -4188,7 +3893,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -4201,7 +3905,6 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -4214,22 +3917,19 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
             "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/vscode-textmate": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
             "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -4245,7 +3945,6 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -4264,7 +3963,6 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -4282,7 +3980,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -4291,15 +3988,13 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -4314,7 +4009,6 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -4327,7 +4021,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4340,7 +4033,6 @@
             "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
             "integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.9"
             }
@@ -4349,7 +4041,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
@@ -4358,7 +4049,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -4376,7 +4066,6 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
@@ -4385,7 +4074,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -4393,14 +4081,12 @@
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/yargs/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -4414,7 +4100,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },


### PR DESCRIPTION
## Summary
- Upgrade `smpita/configas` from v1.4.1 to v2.0.1
- Upgrade `smpita/typeas` from v3.2.2 to v4.0.2
- Update Laravel Boost guidelines with new package documentation

## Test plan
- [x] All 37 tests pass
- [x] PHPStan static analysis passes with no errors
- [x] Frontend build succeeds
- [x] No breaking changes detected in existing code usage